### PR TITLE
Settings: Poximity wake

### DIFF
--- a/res/values/gzosp_strings.xml
+++ b/res/values/gzosp_strings.xml
@@ -24,5 +24,9 @@
 
     <string name="show_dev_already_enabled">No Need, Development settings are enabled by default.</string>
 
+    <!-- Proximity wake -->
+    <string name="proximity_wake_title">Prevent accidental wake up</string>
+    <string name="proximity_wake_summary">Check the proximity sensor prior to waking up screen</string>
+
 </resources>
 

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -111,6 +111,12 @@
         android:fragment="com.android.settings.gestures.PickupGestureSettings" />
 
     <SwitchPreference
+        android:key="proximity_on_wake"
+        android:title="@string/proximity_wake_title"
+        android:summary="@string/proximity_wake_summary"
+        android:defaultValue="true" />
+
+    <SwitchPreference
         android:key="doze"
         android:title="@string/doze_title"
         android:summary="@string/doze_summary" />

--- a/src/com/android/settings/DisplaySettings.java
+++ b/src/com/android/settings/DisplaySettings.java
@@ -33,6 +33,7 @@ import com.android.settings.display.FontSizePreferenceController;
 import com.android.settings.display.LiftToWakePreferenceController;
 import com.android.settings.display.NightDisplayPreferenceController;
 import com.android.settings.display.NightModePreferenceController;
+import com.android.settings.display.ProximityOnWakePreferenceController;
 import com.android.settings.display.ScreenSaverPreferenceController;
 import com.android.settings.display.TapToWakePreferenceController;
 import com.android.settings.display.ThemePreferenceController;
@@ -99,6 +100,7 @@ public class DisplaySettings extends DashboardFragment {
         controllers.add(new LiftToWakePreferenceController(context));
         controllers.add(new NightDisplayPreferenceController(context));
         controllers.add(new NightModePreferenceController(context));
+        controllers.add(new ProximityOnWakePreferenceController(context));        
         controllers.add(new ScreenSaverPreferenceController(context));
         AmbientDisplayConfiguration ambientDisplayConfig = new AmbientDisplayConfiguration(context);
         controllers.add(new PickupGesturePreferenceController(

--- a/src/com/android/settings/display/ProximityOnWakePreferenceController.java
+++ b/src/com/android/settings/display/ProximityOnWakePreferenceController.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.android.settings.display;
+
+import android.content.Context;
+import android.provider.Settings;
+import android.support.v14.preference.SwitchPreference;
+import android.support.v7.preference.Preference;
+
+import com.android.settings.core.PreferenceController;
+
+public class ProximityOnWakePreferenceController extends PreferenceController implements
+        Preference.OnPreferenceChangeListener {
+
+    private static final String KEY_PROXIMITY_WAKE = "proximity_on_wake";
+
+    public ProximityOnWakePreferenceController(Context context) {
+        super(context);
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return KEY_PROXIMITY_WAKE;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return mContext.getResources().getBoolean(
+                com.android.internal.R.bool.config_proximityCheckOnWake);
+    }
+
+    @Override
+    public void updateState(Preference preference) {
+        int value = Settings.System.getInt(
+                mContext.getContentResolver(), Settings.System.PROXIMITY_ON_WAKE, 0);
+        ((SwitchPreference) preference).setChecked(value != 0);
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        boolean value = (Boolean) newValue;
+        Settings.System.putInt(
+                mContext.getContentResolver(), Settings.System.PROXIMITY_ON_WAKE, value ? 1 : 0);
+        return true;
+    }
+}


### PR DESCRIPTION
Adapted to oreo gave it it's own fragment

In order to use you must add this config within device:

    <!-- Default value for proximity check on screen wake
         NOTE ! - Enable for devices that have a fast response
         proximity sensor (ideally < 300ms) -->
    <bool name="config_proximityCheckOnWake">true</bool>
    <bool name="config_proximityCheckOnWakeEnabledByDefault">true</bool>