### PR TITLE
Display network name in status bar(2/2)

### DIFF
--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -99,4 +99,7 @@
         -->
     </string-array>
 
+    <!-- Whether to enable "show operator name in the status bar" setting -->
+    <bool name="config_showOperatorNameInStatusBar">false</bool>
+
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -8679,5 +8679,8 @@
     <!-- The divider symbol between different parts of the notification header including spaces. not translatable [CHAR LIMIT=3] -->
     <string name="notification_header_divider_symbol_with_spaces" translatable="false">" • "</string>
 
-
+    <!-- Switch label to show operator name in the status bar [CHAR LIMIT=60] -->
+    <string name="show_operator_name_title">Network name</string>
+    <!-- Switch summary to show operator name in the status bar [CHAR LIMIT=NONE] -->
+    <string name="show_operator_name_summary">Display network name in status bar</string>
 </resources>

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -92,6 +92,11 @@
         android:entryValues="@array/night_mode_values" /> -->
 
     <SwitchPreference
+        android:key="show_operator_name"
+        android:title="@string/show_operator_name_title"
+        android:summary="@string/show_operator_name_summary" />
+
+    <SwitchPreference
         android:key="camera_gesture"
         android:title="@string/camera_gesture_title"
         android:summary="@string/camera_gesture_desc" />

--- a/src/com/android/settings/DisplaySettings.java
+++ b/src/com/android/settings/DisplaySettings.java
@@ -35,6 +35,7 @@ import com.android.settings.display.NightDisplayPreferenceController;
 import com.android.settings.display.NightModePreferenceController;
 import com.android.settings.display.ProximityOnWakePreferenceController;
 import com.android.settings.display.ScreenSaverPreferenceController;
+import com.android.settings.display.ShowOperatorNamePreferenceController;
 import com.android.settings.display.TapToWakePreferenceController;
 import com.android.settings.display.ThemePreferenceController;
 import com.android.settings.display.TimeoutPreferenceController;
@@ -102,6 +103,7 @@ public class DisplaySettings extends DashboardFragment {
         controllers.add(new NightModePreferenceController(context));
         controllers.add(new ProximityOnWakePreferenceController(context));        
         controllers.add(new ScreenSaverPreferenceController(context));
+        controllers.add(new ShowOperatorNamePreferenceController(context));
         AmbientDisplayConfiguration ambientDisplayConfig = new AmbientDisplayConfiguration(context);
         controllers.add(new PickupGesturePreferenceController(
                 context, lifecycle, ambientDisplayConfig, UserHandle.myUserId(), KEY_PICK_UP));

--- a/src/com/android/settings/display/ShowOperatorNamePreferenceController.java
+++ b/src/com/android/settings/display/ShowOperatorNamePreferenceController.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.android.settings.display;
+
+import android.content.Context;
+import android.provider.Settings;
+import android.support.v14.preference.SwitchPreference;
+import android.support.v7.preference.Preference;
+
+import com.android.settings.R;
+import com.android.settings.core.PreferenceController;
+
+public class ShowOperatorNamePreferenceController extends PreferenceController implements
+        Preference.OnPreferenceChangeListener {
+
+    private static final String KEY_SHOW_OPERATOR_NAME = "show_operator_name";
+
+    public ShowOperatorNamePreferenceController(Context context) {
+        super(context);
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return mContext.getResources().getBoolean(R.bool.config_showOperatorNameInStatusBar);
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return KEY_SHOW_OPERATOR_NAME;
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        boolean value = (Boolean) newValue;
+        Settings.Secure.putInt(mContext.getContentResolver(),
+                KEY_SHOW_OPERATOR_NAME, value ? 1 : 0);
+        return true;
+    }
+
+    @Override
+    public void updateState(Preference preference) {
+        int value = Settings.Secure.getInt(mContext.getContentResolver(),
+                KEY_SHOW_OPERATOR_NAME, 1);
+        ((SwitchPreference) preference).setChecked(value != 0);
+    }
+}

--- a/tests/robotests/src/com/android/settings/display/ShowOperatorNamePreferenceControllerTest.java
+++ b/tests/robotests/src/com/android/settings/display/ShowOperatorNamePreferenceControllerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import android.content.Context;
+import android.provider.Settings;
+import android.support.v14.preference.SwitchPreference;
+
+import com.android.settings.R;
+import com.android.settings.testutils.SettingsRobolectricTestRunner;
+import com.android.settings.TestConfig;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.annotation.Config;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(SettingsRobolectricTestRunner.class)
+@Config(manifest = TestConfig.MANIFEST_PATH, sdk = TestConfig.SDK_VERSION)
+public class ShowOperatorNamePreferenceControllerTest {
+
+    private static final String KEY_SHOW_OPERATOR_NAME = "show_operator_name";
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private Context mContext;
+    @Mock
+    private SwitchPreference mPreference;
+
+    private ShowOperatorNamePreferenceController mController;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        mController = new ShowOperatorNamePreferenceController(mContext);
+    }
+
+    @Test
+    public void testIsAvailable_configIsTrue_ReturnTrue() {
+        when(mContext.getResources().getBoolean(R.bool.config_showOperatorNameInStatusBar))
+                .thenReturn(true);
+        assertThat(mController.isAvailable()).isTrue();
+    }
+
+    @Test
+    public void testIsAvailable_configIsFalse_ReturnFalse() {
+        when(mContext.getResources().getBoolean(R.bool.config_showOperatorNameInStatusBar))
+                .thenReturn(false);
+        assertThat(mController.isAvailable()).isFalse();
+    }
+
+    @Test
+    public void testOnPreferenceChange_TurnOn_ReturnOn() {
+        mController.onPreferenceChange(mPreference, true);
+
+        final int mode = Settings.Secure.getInt(mContext.getContentResolver(),
+                KEY_SHOW_OPERATOR_NAME, 0);
+        assertThat(mode).isEqualTo(1);
+    }
+
+    @Test
+    public void testOnPreferenceChange_TurnOff_ReturnOff() {
+        mController.onPreferenceChange(mPreference, false);
+
+        final int mode = Settings.Secure.getInt(mContext.getContentResolver(),
+                KEY_SHOW_OPERATOR_NAME, 1);
+        assertThat(mode).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
When config_showOperatorNameInStatusBar is true, "Network name" setting
is displayed in Settings app (Settings > Display).
The user can turn on/off the feature to display the network name in the
status bar from Settings app.

Fixes: 67620513
Test: manual - go to Settings > Display and turn on/off Network name.

Change-Id: I43f1d9cbea363527250639ce6146f1c5c6c8a482