### PR TITLE
The blueman group have left the building..

### DIFF
--- a/res/layout-night/suggestion_tile.xml
+++ b/res/layout-night/suggestion_tile.xml
@@ -26,7 +26,7 @@
 
     <ImageView
         android:id="@android:id/icon"
-        android:tint="@*android:color/accent_device_default_light"
+        android:tint="#FAFAFA"
         android:layout_width="@dimen/dashboard_tile_image_size"
         android:layout_height="@dimen/dashboard_tile_image_size"
         android:layout_marginStart="@dimen/dashboard_tile_image_margin_start"

--- a/res/values-night/styles.xml
+++ b/res/values-night/styles.xml
@@ -16,7 +16,7 @@
     </style>
 
     <style name="Theme.SettingsBase" parent="@*android:style/Theme.Material">
-        <item name="android:colorBackground">@*android:color/background_floating_material_dark</item>
+        <item name="android:colorBackground">#000000</item>
         <item name="android:windowBackground">@*android:color/background_dark</item>
         <item name="android:textColorPrimaryInverse">#ffffffff</item>
     </style>
@@ -25,10 +25,10 @@
     <style name="Theme.AlertDialog" parent="@*android:style/Theme.Material.Dialog.Alert">
         <item name="android:textColorPrimary">#ffffffff</item>
         <item name="android:textColorSecondary">#ffdddddd</item>
-        <item name="android:colorBackground">@*android:color/background_floating_material_dark</item>
-        <item name="android:colorPrimary">@*android:color/primary_material_dark</item>
+        <item name="android:colorBackground">#000000</item>
+        <item name="android:colorPrimary">#000000</item>
         <item name="android:colorPrimaryDark">@*android:color/primary_dark_material_dark</item>
-        <item name="android:colorAccent">@*android:color/accent_material_dark</item>
+        <item name="android:colorAccent">#FAFAFA</item>
     </style>
 
 
@@ -39,7 +39,7 @@
     <style name="FallbackHome" parent="@*android:style/Theme.DeviceDefault" />
     <style name="PreferenceFragmentListSinglePane" parent="@*android:style/PreferenceFragmentList">
         <item name="android:scrollbarStyle">outsideOverlay</item>
-        <item name="android:background">@*android:color/background_dark</item>
+        <item name="android:background">#000000</item>
     </style>
 
     <style name="Theme.SettingsAlertDialog" parent="@*android:style/Theme.Material.Dialog.Alert" />


### PR DESCRIPTION
No idea why google left the On-body detection icon tint to blue but to
me it was way outta place.
Added a default tint "accent_device_default_light" in the suggestion
tile layout to keep it at least looking tidy and most likely help
themers in the long run.
Thanks to @daveyannihilation for the tips in the past and leading me
in the proper direction for icon tint.

Change-Id: I424ac1edb8c0c65d2888fcb32bee34048df71e43